### PR TITLE
fix arm64 docker build

### DIFF
--- a/.github/workflows/astria-build-and-publish-image.yml
+++ b/.github/workflows/astria-build-and-publish-image.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checking out the repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Setting up Go
       - uses: actions/setup-go@v4
         with:
@@ -38,13 +38,17 @@ jobs:
 
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Log in to registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       # Generate correct tabs and labels
       - name: Docker metadata
         id: metadata
@@ -65,6 +69,7 @@ jobs:
           context: .
           # It takes over 30 minutes to build the arm image right now, so we only build it on tags which is what we use for releases.
           platforms: ${{ contains(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          push: true
+          # push: true
+          push: false
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/astria-build-and-publish-image.yml
+++ b/.github/workflows/astria-build-and-publish-image.yml
@@ -68,7 +68,8 @@ jobs:
           file: ./docker/Dockerfile.test
           context: .
           # It takes over 30 minutes to build the arm image right now, so we only build it on tags which is what we use for releases.
-          platforms: ${{ contains(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          # platforms: ${{ contains(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: linux/amd64,linux/arm64
           # push: true
           push: false
           tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/astria-build-and-publish-image.yml
+++ b/.github/workflows/astria-build-and-publish-image.yml
@@ -70,7 +70,7 @@ jobs:
           # It takes over 30 minutes to build the arm image right now, so we only build it on tags which is what we use for releases.
           # platforms: ${{ contains(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           platforms: linux/amd64,linux/arm64
-          # push: true
-          push: false
+          push: true
+          # push: false
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/astria-build-and-publish-image.yml
+++ b/.github/workflows/astria-build-and-publish-image.yml
@@ -70,7 +70,7 @@ jobs:
           # It takes over 30 minutes to build the arm image right now, so we only build it on tags which is what we use for releases.
           # platforms: ${{ contains(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           platforms: linux/amd64,linux/arm64
-          push: true
-          # push: false
+          # push: true
+          push: false
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/astria-build-and-publish-image.yml
+++ b/.github/workflows/astria-build-and-publish-image.yml
@@ -68,9 +68,7 @@ jobs:
           file: ./docker/Dockerfile.test
           context: .
           # It takes over 30 minutes to build the arm image right now, so we only build it on tags which is what we use for releases.
-          # platforms: ${{ contains(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          platforms: linux/amd64,linux/arm64
-          # push: true
-          push: false
+          platforms: ${{ contains(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -2,7 +2,7 @@
 # > docker build -t metro .
 # > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.metro:/root/.metro -v ~/.metrocli:/root/.metrocli metro metro init
 # > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.metro:/root/.metro -v ~/.metrocli:/root/.metrocli metro metro start
-FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS build-env
+FROM golang:1.19-alpine AS build-env
 
 # Set up dependencies
 ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
@@ -14,6 +14,8 @@ WORKDIR /go/src/github.com/histolabs/metro
 COPY . .
 
 # Install minimum necessary dependencies, build Cosmos SDK, remove packages
+ARG TARGETPLATFORM
+RUN compile
 RUN apk add --no-cache $PACKAGES && \
     make install
 

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -14,13 +14,11 @@ WORKDIR /go/src/github.com/histolabs/metro
 COPY . .
 
 # Install minimum necessary dependencies, build Cosmos SDK, remove packages
-ARG TARGETPLATFORM
-RUN compile
 RUN apk add --no-cache $PACKAGES && \
     make install
 
 # Final image
-FROM --platform=$BUILDPLATFORM alpine:edge
+FROM alpine:edge
 
 # Install ca-certificates
 RUN apk add --update ca-certificates


### PR DESCRIPTION
In order to make use of smarter multiplatform builds, `BUILDPLATFORM` and `TARGETPLATFORM` need to be used in conjunction, with `TARGETPLATFORM` being passed in the compilation step.

For that to work in turn the `Makefile` needs to be adjusted, which means more changes.

This PR removes `--$BUILDPLATFORM` from the dockerfile, which in turn makes the argument `--platform linux/amd64,linux/arm64` to `docker buildx build` work again, relying on qemu static user emulation.

While slow, it compiles linux/arm64 without extra work.